### PR TITLE
 Remove secs inside pseudocode of BBRPickProbeWait 

### DIFF
--- a/draft-cardwell-ccwg-bbr.xml
+++ b/draft-cardwell-ccwg-bbr.xml
@@ -1067,7 +1067,7 @@ sustain its achievable throughput.</t>
       random_int_between(0, 1); /* 0 or 1 */
     /* Decide the random wall clock bound for wait: */
     BBR.bw_probe_wait =
-      2 + random_float_between(0.0, 1.0) /* 0..1 sec */ secs
+      2 + random_float_between(0.0, 1.0) /* 0..1 sec */
 
   BBRIsRenoCoexistenceProbeTime():
     reno_rounds = BBRTargetInflight()


### PR DESCRIPTION
This pull request removes the non-pseudocode keyword 'secs'.
I think the keyword 'secs' was unnecessary and not part of the pseudocode structure.