### PR TITLE
Use consistent value for drain pacing gain which matches derivation doc

### DIFF
--- a/draft-ietf-ccwg-bbr.md
+++ b/draft-ietf-ccwg-bbr.md
@@ -374,7 +374,7 @@ Drain mode, to attempt to drain the estimated queue at the bottleneck link
 in
 one round-trip or less. As noted in {{BBRDrainPacingGain}}, any
 value at or below 1 / BBRStartupCwndGain = 1 / 2 = 0.5 will theoretically
-achieve this. BBR uses the value 0.35, which has been shown to offer good
+achieve this. BBR uses the value 0.5, which has been shown to offer good
 performance when compared with other alternatives.
 
 
@@ -1148,12 +1148,12 @@ before attempting to drain the level of in-flight data to the estimated BDP.
 
 ### Drain {#drain}
 
-Upon exiting Startup, BBR enters its Drain state. In Drain, BBR aims to quickly
-drain any queue at the bottleneck link that was created in Startup by switching
-to a pacing_gain well below 1.0, until any estimated queue has been drained. It
-uses a pacing_gain of BBRDrainPacingGain = 0.35, chosen via analysis
-{{BBRDrainPacingGain}} and experimentation to try to drain the queue in less
-than one round-trip:
+Upon exiting Startup, BBR enters its Drain state. In Drain, BBR aims to
+quickly drain any queue at the bottleneck link that was created in Startup by
+switching to a pacing_gain well below 1.0, until any estimated queue has been
+drained. It uses a pacing_gain of BBRDrainPacingGain, with a value chosen
+via analysis {{BBRDrainPacingGain}} and experimentation to try to drain the
+queue in less than one round-trip:
 
 
 ~~~~


### PR DESCRIPTION
The drain gain value is inconsistent. The derivation doc linked (https://github.com/google/bbr/blob/master/Documentation/startup/gain/analysis/bbr_drain_gain.pdf) suggests using 0.5 and that's the value referenced in the table under (Summary of Control Behavior in the State Machine).  0.35 (~ 1 / StartupPacingGain) is used in a couple of other places.

This PR changes it to 0.5 everywhere. 

Existing implementations are using 0.35 ([Linux TCP](https://github.com/google/bbr/blob/v3/net/ipv4/tcp_bbr.c#L221C46-L221C51), [Quiche](https://github.com/google/quiche/blob/73107195dfbe8f0a531d3e2f052c9f2e15ec0e3c/quiche/quic/core/congestion_control/bbr2_misc.h#L111), [Mvfst](https://github.com/facebook/mvfst/blob/main/quic/congestion_control/Bbr2.cpp#L27)). The 0.5 value can be regarded as an upper bound. 

This PR will keep the value consistent in the draft while we test the impact of the changing it to 0.5.