### PR TITLE
BBRIsProbingBW() is not implemented

### DIFF
--- a/draft-ietf-ccwg-bbr.md
+++ b/draft-ietf-ccwg-bbr.md
@@ -1644,6 +1644,11 @@ The ancillary logic to implement the ProbeBW state machine:
       return true  /* we estimate we've fully used path bw */
     return false
 
+  BBRIsProbingBW():
+    return (BBR.state == Startup or
+            BBR.state == ProbeBW_REFILL or
+            BBR.state == ProbeBW_UP)
+
   BBRHasElapsedInPhase(interval):
     return Now() > BBR.cycle_stamp + interval
 
@@ -3705,7 +3710,7 @@ and the YouTube, google.com, Bandwidth Enforcer, and Google SRE teams for
 their invaluable help and support. We would like to thank Randall R. Stewart,
 Jim Warner, Loganaden Velvindron, Hiren Panchasara, Adrian Zapletal, Christian
 Huitema, Bao Zheng, Jonathan Morton, Matt Olson, Junho Choi, Carsten Bormann,
-Pouria Mousavizadeh Tehrani, and Amanda Baber
+Pouria Mousavizadeh Tehrani, Amanda Baber and Frédéric Lécaille
 for feedback, suggestions, and edits on earlier versions of this document.
 
 


### PR DESCRIPTION
According to this draft in relation with BBRAdaptLowerBoundsFromCongestion():

  4.5.10.3. When not Probing for Bandwidth
  When not explicitly accelerating to probe for bandwidth (Drain, ProbeRTT,
  ProbeBW_DOWN, ProbeBW_CRUISE), BBR responds to loss by slowing down to some
  extent.

this function should exclude the BBR states which are not aforementioned, that is to say Startup, ProbeBW_UP and ProbeBW_REFILL calling BBRIsProbingBW(). So, this latter should be implemented as follows:

BBRIsProbingBW():
	return BBR.state == Startup or
	       BBR.state == ProbeBW_UP or
	       BBR.state == ProbeBW_REFILL

This patch directly inlines the code of BBRIsProbingBW().