### PR TITLE
Remove some TCP and SACK references

### DIFF
--- a/draft-ietf-ccwg-bbr.md
+++ b/draft-ietf-ccwg-bbr.md
@@ -2753,9 +2753,9 @@ when the most recently ACKed packet was sent. And the BBRBeta (0.7x) bound
 is to try to ensure that BBR does not react more dramatically than CUBIC's
 0.7x multiplicative decrease factor.
 
-Some loss detection algorithms, including algorithms like RACK
-{{RFC8985}} or QUIC loss detection {{RFC9002}}, delay loss marking to wait
-for potential reordering, so may mark packets as lost long after the loss itself
+Some loss detection algorithms, including RACK {{RFC8985}} or QUIC loss
+detection {{RFC9002}}, delay loss marking to wait for potential
+reordering, so packets can be declared lost long after the loss itself.
 happened. In such cases, the tx_in_flight for the delivered sequence range
 that allowed the loss to be detected may be considerably smaller than the
 tx_in_flight of the lost packet itself. In such cases using the former

--- a/draft-ietf-ccwg-bbr.md
+++ b/draft-ietf-ccwg-bbr.md
@@ -1669,7 +1669,7 @@ is deemed a sufficient attempt to coordinate to drain the queue.
 
 #### Calculating the rs.rtt RTT Sample {#calculating-the-rsrtt-rtt-sample}
 
-Upon transmitting each packet, BBR or the underlying transport protocol
+Upon transmitting each packet, BBR or the associated transport protocol
 stores in per-packet data the wall-clock scheduled transmission time of the
 packet in packet.departure_time (see "Pacing Rate: BBR.pacing_rate" in
 {{pacing-rate-bbrpacingrate}} for how this is calculated).

--- a/draft-ietf-ccwg-bbr.md
+++ b/draft-ietf-ccwg-bbr.md
@@ -2215,9 +2215,9 @@ This algorithm requires the following new state variables for each packet
 that has been transmitted but has not been acknowledged:
 
 P.delivered: C.delivered when the packet was sent from transport connection
-C. TODO: I'm not sure what this is for?
+C.
 
-P.delivered_time: C.delivered_time when the packet was delivered TODO: Does my reword work?
+P.delivered_time: C.delivered_time when the packet was sent.
 
 P.is_app_limited: true if C.app_limited was non-zero when the packet was
 sent, else false.


### PR DESCRIPTION
This attempts to keep them when they're relevant and may have missed some.

Also there are some TODOs where I was confused what the text intended.  Hopefully @nealcardwell can let me know how to fix those.

Fixes #4