### PR TITLE
Ensure BBRCheckFullBWReached pseudo code counts three full rounds

### DIFF
--- a/draft-ietf-ccwg-bbr.md
+++ b/draft-ietf-ccwg-bbr.md
@@ -1036,11 +1036,11 @@ new data, and when the delivery rate sample is not application-limited
   BBRCheckFullBWReached():
     if (BBR.full_bw_now or rs.is_app_limited)
       return  /* no need to check for a full pipe now */
+    if (!BBR.round_start)
+      return
     if (rs.delivery_rate >= BBR.full_bw * 1.25)
       BBRResetFullBW()       /* bw is still growing, so reset */
       BBR.full_bw = rs.delivery_rate  /* record new baseline bw */
-      return
-    if (!BBR.round_start)
       return
     BBR.full_bw_count++   /* another round w/o much growth */
     BBR.full_bw_now = (BBR.full_bw_count >= 3)

--- a/draft-ietf-ccwg-bbr.md
+++ b/draft-ietf-ccwg-bbr.md
@@ -1034,10 +1034,8 @@ new data, and when the delivery rate sample is not application-limited
 
 ~~~~
   BBRCheckFullBWReached():
-    if (BBR.full_bw_now or rs.is_app_limited)
+    if (BBR.full_bw_now or !BBR.round_start or rs.is_app_limited)
       return  /* no need to check for a full pipe now */
-    if (!BBR.round_start)
-      return
     if (rs.delivery_rate >= BBR.full_bw * 1.25)
       BBRResetFullBW()       /* bw is still growing, so reset */
       BBR.full_bw = rs.delivery_rate  /* record new baseline bw */


### PR DESCRIPTION
In the text description of the full pipe estimator, it counts three rounds. 

> if BBR counts several (three) non-application-limited rounds where attempts to significantly increase the
delivery rate actually result in little increase (less than 25 percent)

However, the pseudocode allows the full bw to be reset anytime during the round. Depending on the point in time in the round when this happens, this could reduce the time spent in the bandwdith plateau by up to one round. 

By moving the check for round_start earlier, the estimator is guaranteed to spend 3 full round trips in the plateau.