### PR TITLE
Revert recent prose about P.first_sent_time

### DIFF
--- a/draft-ietf-ccwg-bbr.md
+++ b/draft-ietf-ccwg-bbr.md
@@ -2218,14 +2218,12 @@ C.
 
 P.delivered_time: C.delivered_time when the packet was sent.
 
+P.first_sent_time: C.first_sent_time when the packet was sent.
+
 P.is_app_limited: true if C.app_limited was non-zero when the packet was
 sent, else false.
 
 P.sent_time: The time when the packet was sent.
-
-Additionally, TCP and other transport protocols that retransmit packets require:
-
-P.first_sent_time: C.first_sent_time when the packet was sent.
 
 ###### Rate Sample (rs) Output {#rate-sample-rs-output}
 


### PR DESCRIPTION
Commit ea7c7c3f116ccec685c476 added some commentary about first_sent_time: "Additionally, TCP and other transport protocols that retransmit packets require".

But first_sent_time is not really about retransmits. Rather, it's about the first send time for a flight of outstanding data in the network, and is used for
computing the time elapsed to send the currently
outstanding flight of data.

This commit removes the commentary and moves
the definition of P.first_sent_time back to its original spot.