### PR TITLE
fix awkward \* on a line by itself

### DIFF
--- a/draft-ietf-ccwg-bbr.md
+++ b/draft-ietf-ccwg-bbr.md
@@ -1233,16 +1233,13 @@ following approach:
   less). The increasingly rapid growth over time is motivated by the fact that
   in a high-speed WAN the increase in available bandwidth (and thus the estimated
   BDP) may require the flow to grow the volume of its inflight data by up to
-  O(1,000,000) packets; even a quite typical high-speed WAN BDP like 10Gbps
-  \*
-  100ms is around 83,000 packets (with a 1500-byte MTU). BBR takes an approach
-  where the additive increase to BBR.inflight_longterm exponentially doubles each
-  round trip; in each successive round trip, inflight_longterm grows by
-  1, 2, 4, 8, 16, etc, with the increases spread uniformly across the entire
-  round trip. This helps allow BBR to utilize a larger BDP in O(log(BDP)) round
-  trips, meeting the design goal for scalable utilization of newly-available
-  bandwidth.
-
+  O(1,000,000) packets; even a quite typical high-speed WAN BDP like
+  10Gbps \* 100ms is around 83,000 packets (with a 1500-byte MTU). The additive
+  increase to BBR.inflight_longterm exponentially doubles each round trip;
+  in each successive round trip, inflight_longterm grows by 1, 2, 4, 8, 16,
+  etc, with the increases spread uniformly across the entire round trip.
+  This helps allow BBR to utilize a larger BDP in O(log(BDP)) round trips,
+  meeting the design goal for scalable utilization of newly-available bandwidth.
 
 Exit conditions: The BBR flow ends ProbeBW_UP bandwidth probing and
 transitions to ProbeBW_DOWN to try to drain the bottleneck queue when either


### PR DESCRIPTION
A recent edit left this lonely \* on a line by itself.