### PR TITLE
define "acknowledged" and "delivered" in a transport-agnostic way

### DIFF
--- a/draft-ietf-ccwg-bbr.md
+++ b/draft-ietf-ccwg-bbr.md
@@ -27,6 +27,7 @@ author:
   org: Meta
   email: jbeshay@meta.com
 normative:
+  RFC793:
   RFC9293:
   RFC2018:
   RFC7323:
@@ -279,10 +280,10 @@ Variables for connection state (C), per-packet state (P), or per-ACK rate
 sample (rs) that are not defined below are defined in
 {{delivery-rate-samples}}, "Delivery Rate Samples".
 
-In this document, "acknowledged" or "delivered" data means any transmitted data that the
-remote transport endpoint has confirmed that it has received, e.g.,
-via a QUIC ACK Range {{RFC9000}}, TCP cumulative acknowledgment {{RFC793}}, or
-TCP SACK ("Selective Acknowledgment") block {{RFC2018}}.
+In this document, "acknowledged" or "delivered" data means any transmitted
+data that the remote transport endpoint has confirmed that it has received,
+e.g., via a QUIC ACK Range {{RFC9000}}, TCP cumulative acknowledgment
+{{RFC793}}, or TCP SACK ("Selective Acknowledgment") block {{RFC2018}}.
 
 ## Transport Connection State {#transport-connection-state}
 

--- a/draft-ietf-ccwg-bbr.md
+++ b/draft-ietf-ccwg-bbr.md
@@ -279,6 +279,11 @@ Variables for connection state (C), per-packet state (P), or per-ACK rate
 sample (rs) that are not defined below are defined in
 {{delivery-rate-samples}}, "Delivery Rate Samples".
 
+In this document, "acknowledged" or "delivered" data means any transmitted data that the
+remote transport endpoint has confirmed that it has received, e.g.,
+via a QUIC ACK Range {{RFC9000}}, TCP cumulative acknowledgment {{RFC793}}, or
+TCP SACK ("Selective Acknowledgment") block {{RFC2018}}.
+
 ## Transport Connection State {#transport-connection-state}
 
 C.delivered: The total amount of data (tracked in octets or in packets)


### PR DESCRIPTION
Recent commit ea7c7c3f116ccec685c476 made some nice improvements
by replacing verbose, TCP-specific text like "ACKed or SACKed"
with succinct and transport-agnostic terms like "acknowledged".

Let's add text to be very clear about what we  mean by those terms,
s ince they are key, and TCP implementors may be
confused about whether "acknowledged" includes SACKs.
