### PR TITLE
remove accidental call to BBRUpdateAggregationBudget()

### DIFF
--- a/draft-ietf-ccwg-bbr.md
+++ b/draft-ietf-ccwg-bbr.md
@@ -3148,7 +3148,6 @@ as follows:
     return BBRQuantizationBudget(inflight)
 
   BBRUpdateMaxInflight():
-    BBRUpdateAggregationBudget()
     inflight = BBRBDPMultiple(BBR.cwnd_gain)
     inflight += BBR.extra_acked
     BBR.max_inflight = BBRQuantizationBudget(inflight)


### PR DESCRIPTION
Fix issue#35.

We can remove the BBRUpdateAggregationBudget() line.

The correct function is BBRUpdateACKAggregation(). And BBRUpdateACKAggregation() is called and defined elsewhere.
