### PR TITLE
Remove duplicate IsInflightTooHigh() function definition

### DIFF
--- a/draft-ietf-ccwg-bbr.md
+++ b/draft-ietf-ccwg-bbr.md
@@ -3415,7 +3415,8 @@ and the YouTube, google.com, Bandwidth Enforcer, and Google SRE teams for
 their invaluable help and support. We would like to thank Randall R. Stewart,
 Jim Warner, Loganaden Velvindron, Hiren Panchasara, Adrian Zapletal, Christian
 Huitema, Bao Zheng, Jonathan Morton, Matt Olson, Junho Choi, Carsten Bormann,
-Pouria Mousavizadeh Tehrani, Amanda Baber and Frédéric Lécaille
+Pouria Mousavizadeh Tehrani, Amanda Baber, Frédéric Lécaille,
+and Tatsuhiro Tsujikawa
 for feedback, suggestions, and edits on earlier versions of this document.
 
 

--- a/draft-ietf-ccwg-bbr.md
+++ b/draft-ietf-ccwg-bbr.md
@@ -2742,15 +2742,6 @@ reduces BBR.inflight_longterm:
 
 ~~~~
   /* Do loss signals suggest inflight is too high?
-   * If so, react. */
-  IsInflightTooHigh():
-    if (IsInflightTooHigh(rs))
-      if (BBR.bw_probe_samples)
-        BBRHandleInflightTooHigh()
-      return true  /* inflight too high */
-    else
-      return false /* inflight not too high */
-
   IsInflightTooHigh():
     return (rs.lost > rs.tx_in_flight * BBRLossThresh)
 
@@ -2819,9 +2810,9 @@ In pseudocode:
     rs.tx_in_flight = packet.tx_in_flight /* inflight at transmit */
     rs.lost = C.lost - packet.lost /* data lost since transmit */
     rs.is_app_limited = packet.is_app_limited;
-    if (IsInflightTooHigh(rs))
+    if (IsInflightTooHigh())
       rs.tx_in_flight = BBRInflightLongtermFromLostPacket(rs, packet)
-      BBRHandleInflightTooHigh(rs)
+      BBRHandleInflightTooHigh()
 
   /* At what prefix of packet did losses exceed BBRLossThresh? */
   BBRInflightLongtermFromLostPacket(rs, packet):

--- a/draft-ietf-ccwg-bbr.md
+++ b/draft-ietf-ccwg-bbr.md
@@ -2741,7 +2741,7 @@ in flight exceeded what matches the current delivery process on the path, and
 reduces BBR.inflight_longterm:
 
 ~~~~
-  /* Do loss signals suggest inflight is too high?
+  /* Do loss signals suggest inflight is too high? */
   IsInflightTooHigh():
     return (rs.lost > rs.tx_in_flight * BBRLossThresh)
 


### PR DESCRIPTION
Fixes #36.

Remove accidental duplicate IsInflightTooHigh() function definition.