### PR TITLE
Replace C.pipe with synonym C.inflight and clarify C.inflight

### DIFF
--- a/draft-ietf-ccwg-bbr.md
+++ b/draft-ietf-ccwg-bbr.md
@@ -3265,7 +3265,7 @@ ProbeRTT), and is defined as follows:
 #### Modulating cwnd in ProbeRTT {#modulating-cwnd-in-probertt}
 
 If BBR decides it needs to enter the ProbeRTT state (see the "ProbeRTT" section
-below), its goal is to quickly reduce  and drain
+below), its goal is to quickly reduce C.inflight and drain
 the bottleneck queue, thereby allowing measurement of BBR.min_rtt. To implement
 this mode, BBR bounds C.cwnd to BBR.MinPipeCwnd, the minimal value that
 allows pipelining (see the "Minimum cwnd for Pipelining" section, above):


### PR DESCRIPTION
Replace occurrences of C.pipe with the synonym C.inflight, and clarify the definition of C.inflight.

Note that "pipe" is from RFC6675. During the recent PRRbis review process we received the reasonable comment
that using  "pipe" is incorrect (or at least 
confusing/misleading) if the implementation
is not using RFC6675 for loss detection.

So let's standardize on "C.inflight", which is consistent with PRRbis.