### PR TITLE
Remove the date from the metadata

### DIFF
--- a/draft-ietf-ccwg-bbr.md
+++ b/draft-ietf-ccwg-bbr.md
@@ -12,7 +12,7 @@ abbrev: BBR
 area: IETF
 wg: CCWG
 kw: Congestion Control
-date: 2024-10-16
+
 author:
 - role: editor
   name: Neal Cardwell


### PR DESCRIPTION
The date should get inserted by the tooling upon submission, and explicitly specifying it seems to be overriding that.