### PR TITLE
Refine definition of C.SMSS

### DIFF
--- a/draft-ietf-ccwg-bbr.md
+++ b/draft-ietf-ccwg-bbr.md
@@ -296,23 +296,19 @@ e.g., via a QUIC ACK Range {{RFC9000}}, TCP cumulative acknowledgment
 C.SMSS: The Sender Maximum Send Size in bytes. The maximum
 size of a single transmission, including the portion
 of the packet that the transport protocol implementation tracks for
-congestion control purposes.
-C.SMSS MUST include transport protocol payload data.
-C.SMSS MAY include only the transport protocol payload data;
-for example, for TCP BBR implementations the C.SMSS SHOULD be the
-Eff.snd.MSS defined in {{RFC9293, Section 3.7.1}},
-which includes only the TCP transport protocol payload data,
-but not TCP or IP headers.
-C.SMSS MAY include the transport protocol payload data plus
-the transport protocol headers; for example,
-for QUIC BBR implementations
+congestion control purposes. C.SMSS MUST include transport protocol
+payload data. C.SMSS MAY include only the transport protocol payload
+data; for example, for TCP BBR implementations the C.SMSS SHOULD be
+the Eff.snd.MSS defined in {{RFC9293, Section 3.7.1}}, which includes
+only the TCP transport protocol payload data, but not TCP or IP headers.
+C.SMSS MAY include the transport protocol payload data plus the
+transport protocol headers; for example, for QUIC BBR implementations
 the C.SMSS SHOULD be the QUIC "maximum datagram size"
-{{RFC9000, Section 14}}, which includes
-the QUIC payload data plus the QUIC headers,
-but not UDP or IP headers.
-In addition to including transport protocol payload and headers,
-implementations MAY include in C.SMSS the size of other headers,
-such as network-layer or link-layer headers.
+{{RFC9000, Section 14}}, which includes the QUIC payload data plus
+the QUIC headers, but not UDP or IP headers. In addition to including
+transport protocol payload and headers, implementations MAY include
+in C.SMSS the size of other headers, such as network-layer or
+link-layer headers.
 
 C.InitialCwnd: The initial congestion window set by the transport protocol
 implementation for the connection at initialization time.

--- a/draft-ietf-ccwg-bbr.md
+++ b/draft-ietf-ccwg-bbr.md
@@ -294,7 +294,7 @@ e.g., via a QUIC ACK Range {{RFC9000}}, TCP cumulative acknowledgment
 ## Transport Connection State {#transport-connection-state}
 
 C.SMSS: The Sender Maximum Send Size in bytes. The maximum
-size of a single packet transmission, including the portion
+size of a single transmission, including the portion
 of the packet that the transport protocol implementation tracks for
 congestion control purposes.
 C.SMSS MUST include transport protocol payload data.

--- a/draft-ietf-ccwg-bbr.md
+++ b/draft-ietf-ccwg-bbr.md
@@ -293,8 +293,26 @@ e.g., via a QUIC ACK Range {{RFC9000}}, TCP cumulative acknowledgment
 
 ## Transport Connection State {#transport-connection-state}
 
-C.SMSS: The Sender Maximum Segment Size in bytes. This is similar to PMTU
-in QUIC {{RFC9000, Section 14.2}}.
+C.SMSS: The Sender Maximum Send Size in bytes. The maximum
+size of a single packet transmission, including the portion
+of the packet that the transport protocol implementation tracks for
+congestion control purposes.
+C.SMSS MUST include transport protocol payload data.
+C.SMSS MAY include only the transport protocol payload data;
+for example, for TCP BBR implementations the C.SMSS SHOULD be the
+Eff.snd.MSS defined in {{RFC9293, Section 3.7.1}},
+which includes only the TCP transport protocol payload data,
+but not TCP or IP headers.
+C.SMSS MAY include the transport protocol payload data plus
+the transport protocol headers; for example,
+for QUIC BBR implementations
+the C.SMSS SHOULD be the QUIC "maximum datagram size"
+{{RFC9000, Section 14}}, which includes
+the QUIC payload data plus the QUIC headers,
+but not UDP or IP headers.
+In addition to including transport protocol payload and headers,
+implementations MAY include in C.SMSS the size of other headers,
+such as network-layer or link-layer headers.
 
 C.InitialCwnd: The initial congestion window set by the transport protocol
 implementation for the connection at initialization time.


### PR DESCRIPTION
Refine the definition of C.SMSS to make it more precise.

Also try to fix its TCP-centric definition that uses the term "segment", and make it general to any transport protocol implementation, and clarify what implementations MUST and MAY do.

Also clarify what TCP and QUIC implementations SHOULD do, since there is extensive experience with BBR with both of those protocols.

Helps resolve Issue #62  "segment vs packet".