### PR TITLE
set P.tx_in_flight in OnPacketSent()

### DIFF
--- a/draft-ietf-ccwg-bbr.md
+++ b/draft-ietf-ccwg-bbr.md
@@ -1159,6 +1159,7 @@ After each packet transmission, the sender executes the following steps:
     P.delivered_time  = C.delivered_time
     P.delivered       = C.delivered
     P.is_app_limited  = (C.app_limited != 0)
+    P.tx_in_flight    = C.inflight    /* includes data in P */
 ~~~~
 
 


### PR DESCRIPTION
Previously P.tx_in_flight was defined, and read in
BBRHandleLostPacket() pseudocode, but there was no pseudocode to set
P.tx_in_flight. This was an oversight.

This commit inserts a line to set P.tx_in_flight in OnPacketSent(),
matching the behavior in the Linux TCP BBR code.

Closes #77 ("set P.tx_in_flight").
