### PR TITLE
clarify implicit C, BBR, RS parameters and relationship of RS and P in stretch ACKs

### DIFF
--- a/draft-ietf-ccwg-bbr.md
+++ b/draft-ietf-ccwg-bbr.md
@@ -298,8 +298,7 @@ Variables that are not defined below are defined in
 In the pseudocode in this document, all functions have implicit access to the
 (C) connection state and (BBR) congestion control algorithm state for that
 connection. All functions involved in ACK processing additionally have implicit
-access to the the (RS) for per-ack rate sample state for the rate sample
-populated during that ACK processing episode.
+access to the the (RS) for for the rate sample populated processing that ACK.
 
 In this document, "acknowledged" or "delivered" data means any transmitted
 data that the remote transport endpoint has confirmed that it has received,

--- a/draft-ietf-ccwg-bbr.md
+++ b/draft-ietf-ccwg-bbr.md
@@ -1195,7 +1195,7 @@ stretched ACK acknowledges multiple data packets. The connection uses the
 information from the most recently sent packet to update the rate sample:
 
 ~~~~
-  /* Update rs when a packet is acknowledged. */
+  /* Update RS when a packet is acknowledged. */
   UpdateRateSample(Packet P):
     if (P.delivered_time == 0)
       return /* P already acknowledged */

--- a/draft-ietf-ccwg-bbr.md
+++ b/draft-ietf-ccwg-bbr.md
@@ -1186,7 +1186,7 @@ the per-ACK RateSample RS:
     RS.delivery_rate = 0
 ~~~~
 
-Next, for each packet that was newly acknowledged, the connection calls
+Next, for each newly acknowledged packet, the connection calls
 UpdateRateSample() to update the per-ACK rate sample based on a snapshot of
 connection delivery information from the time at which the packet was last
 transmitted. The connection invokes UpdateRateSample() multiple times when a

--- a/draft-ietf-ccwg-bbr.md
+++ b/draft-ietf-ccwg-bbr.md
@@ -1224,7 +1224,7 @@ information from the most recently sent packet to update the rate sample:
              after(P.end_seq, RS.last_end_seq))
 ~~~~
 
-Finally, after the connection has processed all packets acknowledged by this
+Finally, after the connection has processed all newly acknowledged packets for this
 ACK by calling UpdateRateSample() for each packet, the connection invokes
 GenerateRateSample() to finish populating the rate sample, RS:
 

--- a/draft-ietf-ccwg-bbr.md
+++ b/draft-ietf-ccwg-bbr.md
@@ -1188,7 +1188,7 @@ the per-ACK RateSample RS:
 
 Next, for each newly acknowledged packet, the connection calls
 UpdateRateSample() to update the per-ACK rate sample based on a snapshot of
-connection delivery information from the time at which the packet was last
+connection delivery information from the time at which the packet was
 transmitted. The connection invokes UpdateRateSample() multiple times when a
 stretched ACK acknowledges multiple data packets. The connection uses the
 information from the most recently sent packet to update the rate sample:


### PR DESCRIPTION
Clarify that all pseudocode functions have access to implicit (C) and
(BBR) parameters (e.g., via a Transmission Control Block or TCB in
TCP, or a "this" pointer in a C++ implementation of QUIC or other
user-space transports), and ACK-related functions also have access to
an implicit (RS) parameter.

Clarify the relationship of (RS) and (P) in handling for ACKs, which
can mark 0, 1, or many packets as acknowledged:

+ first call InitRateSample() once per ACK
+ then call UpdateRateSample() once per packet P acknowledged by the current ACK
+ finally call GenerateRateSample() after those steps

Fixes #58
