### PR TITLE
s/BBRInflightLongtermFromLostPacket/BBRInflightAtLoss/

### DIFF
--- a/draft-ietf-ccwg-bbr.md
+++ b/draft-ietf-ccwg-bbr.md
@@ -2861,11 +2861,11 @@ In pseudocode:
     RS.lost = C.lost - P.lost /* data lost since transmit */
     RS.is_app_limited = P.is_app_limited;
     if (IsInflightTooHigh())
-      RS.tx_in_flight = BBRInflightLongtermFromLostPacket(rs, packet)
+      RS.tx_in_flight = BBRInflightAtLoss(rs, packet)
       BBRHandleInflightTooHigh()
 
   /* At what prefix of packet did losses exceed BBR.LossThresh? */
-  BBRInflightLongtermFromLostPacket(RS, packet):
+  BBRInflightAtLoss(RS, packet):
     size = packet.size
     /* What was in flight before this packet? */
     inflight_prev = RS.tx_in_flight - size


### PR DESCRIPTION
@ianswett noted that "BBRInflightLongtermFromLostPacket" is long and hard to parse. Let's switch to something shorter, and make it consistent with the name of the variable that the function is returning.