### PR TITLE
Replace uses of "?:" operator with then clause omitted with the equivalent "max()" expression

### DIFF
--- a/draft-ietf-ccwg-bbr.md
+++ b/draft-ietf-ccwg-bbr.md
@@ -1307,7 +1307,7 @@ application-limited:
         C.pending_transmissions == 0 and
         C.inflight < C.cwnd and
         C.lost_out <= C.retrans_out)
-      C.app_limited = (C.delivered + C.inflight) ? : 1
+      C.app_limited = max(C.delivered + C.inflight, 1)
 ~~~~
 
 
@@ -2399,8 +2399,7 @@ to the ProbeRTT state as follows:
       BBRExitProbeRTT()
 
   MarkConnectionAppLimited():
-    C.app_limited =
-      (C.delivered + C.inflight) ? : 1
+    C.app_limited = max(C.delivered + C.inflight, 1)
 ~~~~
 
 


### PR DESCRIPTION
Replace uses of "?:" operator with then clause omitted with the equivalent "max()" expression

The ?: elvis operator with is a compiler extension (like in GCC) and not part of the standard C or C++ specifications.  Use of this operator seems relatively obscure outside the C and linux kernel dev communities.