### PR TITLE
Use MarkConnectionAppLimited() function to remove a duplicate statement

### DIFF
--- a/draft-ietf-ccwg-bbr.md
+++ b/draft-ietf-ccwg-bbr.md
@@ -1307,7 +1307,10 @@ application-limited:
         C.pending_transmissions == 0 and
         C.inflight < C.cwnd and
         C.lost_out <= C.retrans_out)
-      C.app_limited = max(C.delivered + C.inflight, 1)
+      MarkConnectionAppLimited()
+
+  MarkConnectionAppLimited():
+    C.app_limited = max(C.delivered + C.inflight, 1)
 ~~~~
 
 
@@ -2397,9 +2400,6 @@ to the ProbeRTT state as follows:
       BBR.probe_rtt_min_stamp = Now()
       BBRRestoreCwnd()
       BBRExitProbeRTT()
-
-  MarkConnectionAppLimited():
-    C.app_limited = max(C.delivered + C.inflight, 1)
 ~~~~
 
 


### PR DESCRIPTION
In CheckIfApplicationLimited(), call the MarkConnectionAppLimited() function
instead of open-coding the logic to update C.app_limited. This approach is
more clear and reduces duplicate logic.
