### PR TITLE
Ensure BBRIsTimeToCruise() returns

### DIFF
--- a/draft-ietf-ccwg-bbr.md
+++ b/draft-ietf-ccwg-bbr.md
@@ -2183,8 +2183,9 @@ The ancillary logic to implement the ProbeBW state machine:
   BBRIsTimeToCruise():
     if (C.inflight > BBRInflightWithHeadroom())
       return false /* not enough headroom */
-    if (C.inflight <= BBRInflight(BBR.max_bw, 1.0))
-      return true  /* C.inflight <= estimated BDP */
+    if (C.inflight > BBRInflight(BBR.max_bw, 1.0))
+      return false /* C.inflight > estimated BDP */
+    return true
 
   /* Time to transition from UP to DOWN? */
   BBRIsTimeToGoDown():


### PR DESCRIPTION
Currently it doesn't always return true or false.