### PR TITLE
Add links to Delivery Rate Sampling Algorithm state variables

### DIFF
--- a/draft-ietf-ccwg-bbr.md
+++ b/draft-ietf-ccwg-bbr.md
@@ -361,6 +361,8 @@ point in the last packet-timed round trip.
 C.next_send_time: The earliest pacing departure time another packet can be
 sent.
 
+More per-connection variables used for the Delivery Rate Sampling Algorithm are defined in Section [Per-connection (C) state](#per-connection-c-state).
+
 ## Per-ACK Rate Sample State {#per-ack-rate-sample-state}
 
 RS.delivered: The volume of data delivered between the transmission of the
@@ -387,6 +389,8 @@ received).
 RS.lost: The volume of data that was declared lost between the transmission
 and acknowledgment of the packet that has just been ACKed (the most recently
 sent packet among packets ACKed by the ACK that was just received).
+
+More per-packet variables used for the Delivery Rate Sampling Algorithm are defined in Section [Per-packet (P) state](#per-packet-p-state).
 
 
 ## Output Control Parameters {#output-control-parameters}

--- a/draft-ietf-ccwg-bbr.md
+++ b/draft-ietf-ccwg-bbr.md
@@ -361,7 +361,8 @@ point in the last packet-timed round trip.
 C.next_send_time: The earliest pacing departure time another packet can be
 sent.
 
-More per-connection variables used for the Delivery Rate Sampling Algorithm are defined in Section [Per-connection (C) state](#per-connection-c-state).
+More per-connection variables used for the Delivery Rate Sampling Algorithm
+are defined in Section [Per-connection (C) state](#per-connection-c-state).
 
 ## Per-ACK Rate Sample State {#per-ack-rate-sample-state}
 
@@ -390,7 +391,8 @@ RS.lost: The volume of data that was declared lost between the transmission
 and acknowledgment of the packet that has just been ACKed (the most recently
 sent packet among packets ACKed by the ACK that was just received).
 
-More per-packet variables used for the Delivery Rate Sampling Algorithm are defined in Section [Per-packet (P) state](#per-packet-p-state).
+More per-packet variables used for the Delivery Rate Sampling Algorithm are
+defined in Section [Per-packet (P) state](#per-packet-p-state).
 
 
 ## Output Control Parameters {#output-control-parameters}

--- a/draft-ietf-ccwg-bbr.md
+++ b/draft-ietf-ccwg-bbr.md
@@ -314,6 +314,11 @@ data that the remote transport endpoint has confirmed that it has received,
 e.g., via a QUIC ACK Range {{RFC9000}}, TCP cumulative acknowledgment
 {{RFC9293}}, or TCP SACK ("Selective Acknowledgment") block {{RFC2018}}.
 
+## Delivery Rate Sampling State
+
+State used in the delivery rate sampling algorithm is defined in Section
+[Delivery Rate Sampling State Variables](#delivery-rate-sampling-state-variables).
+
 ## Transport Connection State {#transport-connection-state}
 
 C.SMSS: The Sender Maximum Send Size in bytes. The maximum
@@ -1082,7 +1087,7 @@ well in practice for congestion control and telemetry purposes.
 
 ### Detailed Delivery Rate Sampling Algorithm {#detailed-delivery-rate-sampling-algorithm}
 
-#### Variables {#variables}
+#### Delivery Rate Sampling State Variables {#delivery-rate-sampling-state-variables}
 
 ##### Per-connection (C) state {#per-connection-c-state}
 

--- a/draft-ietf-ccwg-bbr.md
+++ b/draft-ietf-ccwg-bbr.md
@@ -316,8 +316,9 @@ e.g., via a QUIC ACK Range {{RFC9000}}, TCP cumulative acknowledgment
 
 ## Delivery Rate Sampling State
 
-State used in the delivery rate sampling algorithm is defined in Section
-[Delivery Rate Sampling State Variables](#delivery-rate-sampling-state-variables).
+Connection and per-packet state used in the delivery rate sampling algorithm
+is defined in Section [Delivery Rate Sampling State Variables]
+(#delivery-rate-sampling-state-variables).
 
 ## Transport Connection State {#transport-connection-state}
 

--- a/draft-ietf-ccwg-bbr.md
+++ b/draft-ietf-ccwg-bbr.md
@@ -314,12 +314,6 @@ data that the remote transport endpoint has confirmed that it has received,
 e.g., via a QUIC ACK Range {{RFC9000}}, TCP cumulative acknowledgment
 {{RFC9293}}, or TCP SACK ("Selective Acknowledgment") block {{RFC2018}}.
 
-## Delivery Rate Sampling State
-
-Connection and per-packet state used in the delivery rate sampling algorithm
-is defined in Section [Delivery Rate Sampling State Variables]
-(#delivery-rate-sampling-state-variables).
-
 ## Transport Connection State {#transport-connection-state}
 
 C.SMSS: The Sender Maximum Send Size in bytes. The maximum
@@ -367,6 +361,11 @@ point in the last packet-timed round trip.
 C.next_send_time: The earliest pacing departure time another packet can be
 sent.
 
+## Delivery Rate Sampling State
+
+Connection and per-packet state used in the delivery rate sampling algorithm
+is defined in Section [Detailed Delivery Rate Sampling Algorithm](#detailed-delivery-rate-sampling-algorithm).
+
 ## Per-ACK Rate Sample State {#per-ack-rate-sample-state}
 
 RS.delivered: The volume of data delivered between the transmission of the
@@ -393,6 +392,7 @@ received).
 RS.lost: The volume of data that was declared lost between the transmission
 and acknowledgment of the packet that has just been ACKed (the most recently
 sent packet among packets ACKed by the ACK that was just received).
+
 
 ## Output Control Parameters {#output-control-parameters}
 
@@ -1081,7 +1081,7 @@ well in practice for congestion control and telemetry purposes.
 
 ### Detailed Delivery Rate Sampling Algorithm {#detailed-delivery-rate-sampling-algorithm}
 
-#### Delivery Rate Sampling State Variables {#delivery-rate-sampling-state-variables}
+#### Variables {#variables}
 
 ##### Per-connection (C) state {#per-connection-c-state}
 

--- a/draft-ietf-ccwg-bbr.md
+++ b/draft-ietf-ccwg-bbr.md
@@ -314,6 +314,12 @@ data that the remote transport endpoint has confirmed that it has received,
 e.g., via a QUIC ACK Range {{RFC9000}}, TCP cumulative acknowledgment
 {{RFC9293}}, or TCP SACK ("Selective Acknowledgment") block {{RFC2018}}.
 
+## Delivery Rate Sampling State
+
+Connection and per-packet state used in the delivery rate sampling algorithm
+is defined in Section [Delivery Rate Sampling State Variables]
+(#delivery-rate-sampling-state-variables).
+
 ## Transport Connection State {#transport-connection-state}
 
 C.SMSS: The Sender Maximum Send Size in bytes. The maximum
@@ -361,11 +367,6 @@ point in the last packet-timed round trip.
 C.next_send_time: The earliest pacing departure time another packet can be
 sent.
 
-## Delivery Rate Sampling State
-
-Connection and per-packet state used in the delivery rate sampling algorithm
-is defined in Section [Detailed Delivery Rate Sampling Algorithm](#detailed-delivery-rate-sampling-algorithm).
-
 ## Per-ACK Rate Sample State {#per-ack-rate-sample-state}
 
 RS.delivered: The volume of data delivered between the transmission of the
@@ -392,7 +393,6 @@ received).
 RS.lost: The volume of data that was declared lost between the transmission
 and acknowledgment of the packet that has just been ACKed (the most recently
 sent packet among packets ACKed by the ACK that was just received).
-
 
 ## Output Control Parameters {#output-control-parameters}
 
@@ -1081,7 +1081,7 @@ well in practice for congestion control and telemetry purposes.
 
 ### Detailed Delivery Rate Sampling Algorithm {#detailed-delivery-rate-sampling-algorithm}
 
-#### Variables {#variables}
+#### Delivery Rate Sampling State Variables {#delivery-rate-sampling-state-variables}
 
 ##### Per-connection (C) state {#per-connection-c-state}
 

--- a/draft-ietf-ccwg-bbr.md
+++ b/draft-ietf-ccwg-bbr.md
@@ -366,9 +366,6 @@ point in the last packet-timed round trip.
 C.next_send_time: The earliest pacing departure time another packet can be
 sent.
 
-More per-connection variables used for the Delivery Rate Sampling Algorithm
-are defined in Section [Per-connection (C) state](#per-connection-c-state).
-
 ## Per-ACK Rate Sample State {#per-ack-rate-sample-state}
 
 RS.delivered: The volume of data delivered between the transmission of the
@@ -395,10 +392,6 @@ received).
 RS.lost: The volume of data that was declared lost between the transmission
 and acknowledgment of the packet that has just been ACKed (the most recently
 sent packet among packets ACKed by the ACK that was just received).
-
-More per-packet variables used for the Delivery Rate Sampling Algorithm are
-defined in Section [Per-packet (P) state](#per-packet-p-state).
-
 
 ## Output Control Parameters {#output-control-parameters}
 


### PR DESCRIPTION
Fixes #68 by adding links from the main Transport Connection State and Per-ACK Rate Sample State sections to the corresponding state sections defined for the Delivery Rate Sampling Algorithm. This makes the full set of state variables easier to discover for readers.

---
*PR created automatically by Jules for task [9041173364766603063](https://jules.google.com/task/9041173364766603063) started by @ianswett*